### PR TITLE
Introduce regex rootPath

### DIFF
--- a/sentry-integration/src/main/kotlin/net/ntworld/sentryIntegration/entity/LocalPath.kt
+++ b/sentry-integration/src/main/kotlin/net/ntworld/sentryIntegration/entity/LocalPath.kt
@@ -27,6 +27,17 @@ data class LocalPath(
                     sentryRootPath = sentryRootPath
                 )
             }
+            
+            if (sentryRootPath.startsWith("^")) {
+                pathRegex = sentryRootPath.toRegex()
+                if (path.contains(pathRegex)) {
+                    return LocalPath(
+                        originValue = input,
+                        value = pathRegex.replace(path, ""),
+                        sentryRootPath = sentryRootPath
+                    )
+                }
+            }
 
             return LocalPath(
                 originValue = input,


### PR DESCRIPTION
The root path of deployments for us is not stable. The format is something like `/fixed/part/GIT_SHA_ID/`. It would be very handy if you could introduce some dynamic behavior to the matching in LocalPath.kt, e.g. regular expression matching. 

I do not have a system set up to test the change, sorry for that. 

Starting the regex with a mandatory, signaling "^" seems reasonable to me, as it a) then only matches the beginning and b) is a pretty unusual character to start a "regular" path.